### PR TITLE
Remove highlighting in console output section

### DIFF
--- a/website/tools/ballerinaByExample/templates/example.tmpl
+++ b/website/tools/ballerinaByExample/templates/example.tmpl
@@ -176,7 +176,7 @@
 
                             <table class="cBBE-body">
                                 {{range .}}
-                                <tr class="cTR{{if not .DocEmpty}} hover-enable{{end}}">
+                                <tr class="cTR{{if and (not .DocEmpty) (not .IsConsoleOutput)}} hover-enable{{end}}">
 
                                     <td class="code{{if .CodeEmpty}} empty{{end}}{{if .CodeLeading}} leading{{end}}{{if .IsConsoleOutput}} cOutput{{end}}">
                                         {{.CodeRendered}}

--- a/website/tools/guides/ballerina.io-guide-theme/base.html
+++ b/website/tools/guides/ballerina.io-guide-theme/base.html
@@ -99,7 +99,7 @@
                       
                       
                       <div class="cGreenBox">
-                          <div class="cGreenBoxTitle">get the code</div>
+                          <div class="cGreenBoxTitle">Refer GitHub</div>
                           
                          
          <div class="">


### PR DESCRIPTION
## Purpose
Remove highlighting in console output section
Change text from "GET THE CODE" to "REFER GITHUB"