### PR TITLE
Use Ballerina service instead of Ballerina program 

### DIFF
--- a/website/two-column-pages/docs/learn/how-to-observe-ballerina-code.md
+++ b/website/two-column-pages/docs/learn/how-to-observe-ballerina-code.md
@@ -1,4 +1,4 @@
-# How to Observe Ballerina Programs
+# How to Observe Ballerina Services
 
 ## Introduction
 Observability is a measure of how well internal states of a system can be inferred from knowledge of its external
@@ -76,7 +76,7 @@ enabled=true
 enabled=true
 ```
 
-The Ballerina program needs to be started as below with either `--config` or `--c` option and provide the path of the
+The Ballerina service needs to be started as below with either `--config` or `--c` option and provide the path of the
 configuration file to adhere to the configuration as shown below.
 
 ```bash
@@ -136,13 +136,13 @@ $ curl http://localhost:9090/hello/sayHello
 
 ## Metrics Monitoring
 Metrics help to monitor the runtime behaviour of a service. Therefore, metrics is a vital part of monitoring
-Ballerina programs. However, metrics is not the same as analytics. For example, you should not use metrics to do
-something like per-request billing. Metrics are used to measure what Ballerina program does at runtime to make
+Ballerina services. However, metrics is not the same as analytics. For example, you should not use metrics to do
+something like per-request billing. Metrics are used to measure what Ballerina service does at runtime to make
 better decisions using the numbers. The code generates business value when it is run in production.
 Therefore, it is imperative to continuously measure the code in production.
 
 Metrics, by default, supports Prometheus. In order to support Prometheus, an HTTP endpoint starts with the context
-of `/metrics` in default port 9797 when starting the Ballerina program.
+of `/metrics` in default port 9797 when starting the Ballerina service.
 
 ### Configure Ballerina
 This section focuses on the Ballerina configurations that are available for metrics monitoring with Prometheus,
@@ -170,14 +170,14 @@ Configuration Key | Description | Default Value | Possible Values
 b7a.observability.metrics.enabled | Whether metrics monitoring is enabled (true) or disabled (false) | false | true or false
 b7a.observability.metrics.provider | Provider name which implements Metrics interface. This is only required to be modified if a custom provider is implemented and needs to be used. | micrometer | micrometer or if any custom implementation, then name of the provider.
 b7a.observability.metrics.micrometer.registry.name | Name of the registry used in micrometer | prometheus | prometheus 
-b7a.observability.metrics.prometheus.port | The value of the port in which the service '/metrics' will be bind to. This service will be used by Prometheus to scrape the information of the Ballerina program. | 9797 | Any suitable value for port 0 - 0 - 65535. However, within that range, ports 0 - 1023 are generally reserved for specific purposes, therefore it is advisable to select a port without that range. 
-b7a.observability.metrics.prometheus.hostname | The hostname in which the service '/metrics' will be bind to. This service will be used by Prometheus to scrape the information of the Ballerina program. | 0.0.0.0 | IP or Hostname or 0.0.0.0 of the node in which the Ballerina program is running.
+b7a.observability.metrics.prometheus.port | The value of the port in which the service '/metrics' will be bind to. This service will be used by Prometheus to scrape the information of the Ballerina service. | 9797 | Any suitable value for port 0 - 0 - 65535. However, within that range, ports 0 - 1023 are generally reserved for specific purposes, therefore it is advisable to select a port without that range. 
+b7a.observability.metrics.prometheus.hostname | The hostname in which the service '/metrics' will be bind to. This service will be used by Prometheus to scrape the information of the Ballerina service. | 0.0.0.0 | IP or Hostname or 0.0.0.0 of the node in which the Ballerina service is running.
 b7a.observability.metrics.prometheus.descriptions | This flag indicates whether meter descriptions should be sent to Prometheus. Turn this off to minimize the amount of data sent on each scrape. | false | true or false
 b7a.observability.metrics.prometheus.step | The step size to use in computing windowed statistics like max. To get the most out of these statistics, align the step interval to be close to your scrape interval. | PT1M (1 minute) | The formats accepted are based on the ISO-8601 duration format PnDTnHnMn.nS with days considered to be exactly 24 hours.
 
 ### Setting up External Systems
 There are mainly two systems involved in collecting and visualizing the metrics. [Prometheus] is used to collect the
-metrics from the Ballerina program and [Grafana] can connect to Prometheus and visualize the metrics in the dashboard.
+metrics from the Ballerina service and [Grafana] can connect to Prometheus and visualize the metrics in the dashboard.
 
 #### Prometheus
 [Prometheus] is used as the monitoring system, which pulls out the metrics collected from the Ballerina service
@@ -185,7 +185,7 @@ metrics from the Ballerina program and [Grafana] can connect to Prometheus and v
 [installation guide](https://prometheus.io/docs/prometheus/latest/installation/).
 
 This section focuses on the quick installation of Prometheus with Docker, and configure it to collect metrics from
-Ballerina program with default configurations. Below provided steps needs to be followed to configure the Prometheus.
+Ballerina service with default configurations. Below provided steps needs to be followed to configure the Prometheus.
 
 **Step 1:** Create a `prometheus.yml` file in `/tmp/` directory.
 
@@ -193,8 +193,8 @@ Ballerina program with default configurations. Below provided steps needs to be 
 
 Go to [official documentation of Prometheus](https://prometheus.io/docs/introduction/first_steps/), if you need more
 information. Please note that the targets should contain the host and port of the `/metrics` service
-that's exposed from Ballerina program for metrics collection. Let's say if the IP of the host in which the Ballerina
-program is running is a.b.c.d and the port is default 9797 (configured from `b7a.observability.metrics.prometheus.port`
+that's exposed from Ballerina service for metrics collection. Let's say if the IP of the host in which the Ballerina
+service is running is a.b.c.d and the port is default 9797 (configured from `b7a.observability.metrics.prometheus.port`
 configuration in Ballerina configuration file), then the sample configuration in Prometheus will be as below.
 
 ```yaml
@@ -309,7 +309,7 @@ b7a.observability.tracing.jaeger.reporter.flush.interval.ms | Jaeger client will
 b7a.observability.tracing.jaeger.reporter.max.buffer.spans | Queue size of the Jaeger client. | 2000 | Any positive integer value.
 
 #### Zipkin Client
-The tracing of Ballerina program can be done via Zipkin as well, but the required dependencies are not included in
+The tracing of Ballerina service can be done via Zipkin as well, but the required dependencies are not included in
 default Ballerina distribution. Follow the below steps to add the required dependencies to the Ballerina distribution.
 
 **Step 1:** Go to [ballerina-observability](https://github.com/ballerina-platform/ballerina-observability) and clone


### PR DESCRIPTION
## Purpose
Use Ballerina service instead of Ballerina program.

## Goals
Here we are explaining about the observability of a Ballerina service.