### PR TITLE
Add connector description to quick start guide

### DIFF
--- a/website/two-column-pages/docs/learn/quick-tour.md
+++ b/website/two-column-pages/docs/learn/quick-tour.md
@@ -118,7 +118,7 @@ Make the resource available at the root as well and change methods to POST. Add 
 
 ## Use a Connector
 
-Ballerina connector is a component which interacts with a network accessible service. It aggregates one or more actions which can be executed on the network accessible service. Ballerina Central stores numerous connectors that can be used with your service. You can search for connectors using ballerina "search" command. The command to search a Twitter connector is mentioned below.
+Ballerina connector is a component that interacts with a network accessible service. It aggregates one or more actions that can be executed on the network accessible service. Ballerina Central stores numerous connectors that can be used with your service. You can search for connectors using the ballerina search command. The command to search a Twitter connector is mentioned below.
 
 ```
 ballerina search twitter

--- a/website/two-column-pages/docs/learn/quick-tour.md
+++ b/website/two-column-pages/docs/learn/quick-tour.md
@@ -118,7 +118,7 @@ Make the resource available at the root as well and change methods to POST. Add 
 
 ## Use a Connector
 
-Ballerina connector is a component that interacts with a network accessible service. It aggregates one or more actions that can be executed on the network accessible service. Ballerina Central stores numerous connectors that can be used with your service. You can search for connectors using the ballerina search command. The command to search a Twitter connector is mentioned below.
+Ballerina connector is a component that interacts with a network accessible service. It aggregates one or more actions that can be executed on the network accessible service. Ballerina Central stores numerous connectors that can be used with your service. You can search for connectors using the `ballerina search` command. The command to search a Twitter connector is mentioned below.
 
 ```
 ballerina search twitter

--- a/website/two-column-pages/docs/learn/quick-tour.md
+++ b/website/two-column-pages/docs/learn/quick-tour.md
@@ -118,7 +118,7 @@ Make the resource available at the root as well and change methods to POST. Add 
 
 ## Use a Connector
 
-Ballerina Central stores numerous connectors that can be used with your service. Search for a Twitter connector.
+Ballerina connector is a component which interacts with a network accessible service. It aggregates one or more actions which can be executed on the network accessible service. Ballerina Central stores numerous connectors that can be used with your service. You can search for connectors using ballerina "search" command. The command to search a Twitter connector is mentioned below.
 
 ```
 ballerina search twitter


### PR DESCRIPTION
This PR adds a description to the "connector" concept at first appearance so that novice user gets an understanding of the concept. 