### PR TITLE
run launcher container as a ballerinauser instead of root

### DIFF
--- a/playground-widget/resources/docker/launcher/Dockerfile
+++ b/playground-widget/resources/docker/launcher/Dockerfile
@@ -15,36 +15,40 @@
 # -----------------------------------------------------------------------
 FROM openjdk:jre-alpine
 
+RUN apk update && apk add --no-cache bash curl unzip \
+    && addgroup ballerina && adduser -g '' -s /bin/bash -D -G ballerina ballerinauser
+
 ENV ENABLE_DEBUG false
 ENV DEBUG_PORT 5005
 
-RUN apk update && apk add bash && apk add curl
-
 COPY ballerinaKeystore.p12 /security/
 COPY docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
-RUN chmod +x /usr/local/bin/docker-entrypoint.sh
-
 COPY ballerina-tools.zip /root/
+
 RUN mkdir /ballerina \
     && unzip /root/ballerina-tools.zip -d /ballerina/ \
     && mv /ballerina/ballerina* /ballerina/runtime \
     && mkdir -p /ballerina/runtime/logs \
-    && rm /root/ballerina-tools.zip
+    && rm /root/ballerina-tools.zip \
+    && chmod +x /usr/local/bin/docker-entrypoint.sh
 
 ENV BALLERINA_HOME /ballerina/runtime
 ENV PATH $BALLERINA_HOME/bin:$PATH
 
 COPY resources /resources/
 COPY services /services/
-RUN chmod +x /services/src/build.sh
-
-RUN cd /services/src/ && sh build.sh\
-    && cp *.balx ../
+RUN chmod +x /services/src/build.sh \
+    && cd /services/src/ && sh build.sh \
+    && cp *.balx ../ \
+    && chown -R ballerinauser:ballerina /services/ /ballerina/
 
 COPY netty-transports.yml /api/
 COPY playground-launcher.jar /api/
 
-EXPOSE 80 8443
+EXPOSE 8080 8443
+USER ballerinauser
+WORKDIR /ballerina/
 
 # TODO: may need to use a signal aware init system because launchers spawn new processes
 ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]
+

--- a/playground-widget/resources/docker/launcher/netty-transports.yml
+++ b/playground-widget/resources/docker/launcher/netty-transports.yml
@@ -17,7 +17,7 @@ listenerConfigurations:
  -
   id: "default-http"
   host: "0.0.0.0"
-  port: 80
+  port: 8080
   scheme: http
  -
   id: "default-https"


### PR DESCRIPTION
## Purpose
> Fix a security vulnerability. 

## Related PRs
> N/A

## Special notes
> This Dockerfile further can be improved to reduce the layers. This is a quick fix to get rid of running container as the root user. The same fix needs to be applied to all other docker files too.
- Any checklist items to be verified before production deployment? It is required to test the complete flow once all docker images are updated to run as ballerinauser
- Special styling concerns? N/A
- Related media files? N/A
