### PR TITLE
Adding star and watch actions to for GitHub repo

### DIFF
--- a/website/two-column-pages/docs/learn/quick-tour.md
+++ b/website/two-column-pages/docs/learn/quick-tour.md
@@ -365,7 +365,7 @@ To start the composer:
 
 ## Follow the Repo
 <p id="iGitStarText">"Star"</p> <p id="iGitWatchText">"Watch"</p>
-Star [GitHub repo](https://github.com/ballerina-platform/ballerina-lang) and show appreciation to Ballerina maintainers for their work. Watching the repo will also help you to keep track of Ballerina project.
+Star [GitHub repo](https://github.com/ballerina-platform/ballerina-lang) and show appreciation to Ballerina maintainers for their work. Watching the repo will also help you keep track of Ballerina project.
 
 ## What's Next
 

--- a/website/two-column-pages/docs/learn/quick-tour.md
+++ b/website/two-column-pages/docs/learn/quick-tour.md
@@ -365,7 +365,7 @@ To start the composer:
 
 ## Follow the Repo
 <p id="iGitStarText">"Star"</p> <p id="iGitWatchText">"Watch"</p>
-Star the [GitHub repo](https://github.com/ballerina-platform/ballerina-lang) and show appreciation to  Ballerina maintainers for their work. Watching the repo will also help you to keep track of Ballerina project.
+Star [GitHub repo](https://github.com/ballerina-platform/ballerina-lang) and show appreciation to  Ballerina maintainers for their work. Watching the repo will also help you to keep track of Ballerina project.
 
 ## What's Next
 

--- a/website/two-column-pages/docs/learn/quick-tour.md
+++ b/website/two-column-pages/docs/learn/quick-tour.md
@@ -307,7 +307,7 @@ $ docker ps
 You see an output similar to the following.
 
 ```
-CONTAINER ID        IMAGE                                     COMMAND                  CREATED                  STATUS                   PORTS                    NAMES
+CONTAINER ID        IMAGE                                     COMMAND                  CREATED                  STATUS              PORTS                    NAMES
 130ded2ae413        registry.hub.docker.com/helloworld:v1.0   "/bin/sh -c 'balleri…"   Less than a second ago   Up 3 seconds        0.0.0.0:9090->9090/tcp   thirsty_hopper
 ```
 

--- a/website/two-column-pages/docs/learn/quick-tour.md
+++ b/website/two-column-pages/docs/learn/quick-tour.md
@@ -365,7 +365,7 @@ To start the composer:
 
 ## Follow the Repo
 <p id="iGitStarText">"Star"</p> <p id="iGitWatchText">"Watch"</p>
-Star [GitHub repo](https://github.com/ballerina-platform/ballerina-lang) and show appreciation to Ballerina maintainers for their work. Watching the repo will also help you keep track of Ballerina project.
+Star [GitHub repo](https://github.com/ballerina-platform/ballerina-lang) and show appreciation to Ballerina maintainers for their work. Watch the repo to keep track of Ballerina issues.
 
 ## What's Next
 

--- a/website/two-column-pages/docs/learn/quick-tour.md
+++ b/website/two-column-pages/docs/learn/quick-tour.md
@@ -363,6 +363,10 @@ To start the composer:
 
 4. Navigate to your service and open it to view this in the Composer.
 
+## Follow the Repo
+<p id="iGitStarText">"Star"</p> <p id="iGitWatchText">"Watch"</p>
+Star the [GitHub repo](https://github.com/ballerina-platform/ballerina-lang) and show appreciation to  Ballerina maintainers for their work. Watching the repo will also help you to keep track of Ballerina project.
+
 ## What's Next
 
 Now that you have taken Ballerina around for a quick twirl, you can explore Ballerina more.

--- a/website/two-column-pages/docs/learn/quick-tour.md
+++ b/website/two-column-pages/docs/learn/quick-tour.md
@@ -365,7 +365,7 @@ To start the composer:
 
 ## Follow the Repo
 <p id="iGitStarText">"Star"</p> <p id="iGitWatchText">"Watch"</p>
-Star [GitHub repo](https://github.com/ballerina-platform/ballerina-lang) and show appreciation to  Ballerina maintainers for their work. Watching the repo will also help you to keep track of Ballerina project.
+Star [GitHub repo](https://github.com/ballerina-platform/ballerina-lang) and show appreciation to Ballerina maintainers for their work. Watching the repo will also help you to keep track of Ballerina project.
 
 ## What's Next
 

--- a/website/two-column-pages/docs/learn/quick-tour.md
+++ b/website/two-column-pages/docs/learn/quick-tour.md
@@ -294,7 +294,7 @@ $ docker images
 If Docker is running, you will see an output similar to the following.
 
 ```
-REPOSITORY                 TAG                 IMAGE ID            CREATED              SIZE
+REPOSITORY                           TAG             IMAGE ID            CREATED              SIZE
 registry.hub.docker.com/helloworld   v1              df83ae43f69b        2 minutes ago        102MB
 ```
 
@@ -307,7 +307,7 @@ $ docker ps
 You see an output similar to the following.
 
 ```
-CONTAINER ID     IMAGE    COMMAND    CREATED      STATUS      PORTS     NAMES
+CONTAINER ID        IMAGE                                     COMMAND                  CREATED                  STATUS                   PORTS                    NAMES
 130ded2ae413        registry.hub.docker.com/helloworld:v1.0   "/bin/sh -c 'balleri…"   Less than a second ago   Up 3 seconds        0.0.0.0:9090->9090/tcp   thirsty_hopper
 ```
 
@@ -364,8 +364,10 @@ To start the composer:
 4. Navigate to your service and open it to view this in the Composer.
 
 ## Follow the Repo
+
 <p id="iGitStarText">"Star"</p> <p id="iGitWatchText">"Watch"</p>
-Star [GitHub repo](https://github.com/ballerina-platform/ballerina-lang) and show appreciation to Ballerina maintainers for their work. Watch the repo to keep track of Ballerina issues.
+
+Star [GitHub repo](https://github.com/ballerina-platform/ballerina-lang)  and show appreciation to Ballerina maintainers for their work. Watch the repo to keep track of Ballerina issues.
 
 ## What's Next
 

--- a/website/two-column-pages/docs/open-source.md
+++ b/website/two-column-pages/docs/open-source.md
@@ -21,10 +21,9 @@ Please see [Ballerina Downloads page](/downloads/) for Ballerina version history
 
 ### Source Code
 
-See our [GitHub repo](https://github.com/ballerina-platform/ballerina-lang).
-
 <p id="iGitStarText">"Star"</p> <p id="iGitWatchText">"Watch"</p>
-Star GitHub repo and show your appreciation to Ballerina maintainers for their work. Watch the repo to keep track of Ballerina issues.
+
+See our [GitHub repo](https://github.com/ballerina-platform/ballerina-lang) and star the repo to show your appreciation to Ballerina maintainers. Watch the repo to keep track of Ballerina issues.
 
 ### Developer Mailing List
 

--- a/website/two-column-pages/docs/open-source.md
+++ b/website/two-column-pages/docs/open-source.md
@@ -23,6 +23,9 @@ Please see [Ballerina Downloads page](/downloads/) for Ballerina version history
 
 See our [GitHub repo](https://github.com/ballerina-platform/ballerina-lang).
 
+<p id="iGitStarText">"Star"</p> <p id="iGitWatchText">"Watch"</p>
+Star GitHub repo and show your appreciation to Ballerina maintainers for their work. Watching the repo will also help you keep track of Ballerina project.
+
 ### Developer Mailing List
 
 [Ballerina-Dev Google Group](https://groups.google.com/forum/#!forum/ballerina-dev) is the main discussion forum of the Ballerina dev team.

--- a/website/two-column-pages/docs/open-source.md
+++ b/website/two-column-pages/docs/open-source.md
@@ -24,7 +24,7 @@ Please see [Ballerina Downloads page](/downloads/) for Ballerina version history
 See our [GitHub repo](https://github.com/ballerina-platform/ballerina-lang).
 
 <p id="iGitStarText">"Star"</p> <p id="iGitWatchText">"Watch"</p>
-Star GitHub repo and show your appreciation to Ballerina maintainers for their work. Watching the repo will also help you keep track of Ballerina project.
+Star GitHub repo and show your appreciation to Ballerina maintainers for their work. Watch the repo to keep track of Ballerina issues.
 
 ### Developer Mailing List
 


### PR DESCRIPTION
## Purpose
Added star and watch button placeholders along with improved section header and text

## Special notes
Please review before commit for both design elements and content

Both quick tour page and open source page has been updated. 
On quick tour, it is in a new section. 
On open source page, it is added within the section Source Code where we point to the repo. 
