### PR TITLE
changed the ballerina installation directory path in Linux

### DIFF
--- a/website/two-column-pages/docs/learn/getting-started.md
+++ b/website/two-column-pages/docs/learn/getting-started.md
@@ -54,7 +54,7 @@ rpm -i <ballerina-binary>.rpm
 
 ## Uninstalling Ballerina
 
-To remove an existing Ballerina installation, delete the Ballerina directory. This is usually `/usr/local/ballerina` under Linux and Mac OS X, and `C:\Ballerina` under Windows.
+To remove an existing Ballerina installation, delete the Ballerina directory. This is usually `/opt/ballerina` under Linux and Mac OS X, and `C:\Ballerina` under Windows.
 
 You should also remove the Ballerina bin directory from your PATH environment variable.
 


### PR DESCRIPTION
## Purpose

When we install ballerina, ballerina directory will create in /opt/ directory. Due to that, we need to edit the "UNINSTALLING BALLERINA" section of the page [1] accordingly. This PR will fix that issue.

[1] - https://stage.ballerina.io/learn/getting-started/#uninstalling-ballerina
