### PR TITLE
Fix Slack link

### DIFF
--- a/website/two-column-pages/docs/help.md
+++ b/website/two-column-pages/docs/help.md
@@ -4,7 +4,7 @@
 | Contact Us | Description |
 | ------------- | :------------- |
 | User Support | Search and post questions with a [#ballerina](https://stackoverflow.com/questions/tagged/ballerina) tag for answers from our engineers and the community. |
-| User Chat | Get live support from other users and Ballerina core team in the [Ballerina Slack channel](https://ballerina-platform.slack.com/). |
+| User Chat | Get live support from other users and Ballerina core team in the [Ballerina Slack channel](https://ballerina.io/open-source/slack/). |
 | Developer Mailing List | Core team and contributors discuss improvements on [Github](https://github.com/ballerina-platform/ballerina-lang) and the [Ballerina Google Group](https://groups.google.com/forum/#!forum/ballerina-dev). |
 | [@ballerinaplat](https://twitter.com/ballerinaplat) | The Ballerina project's official Twitter account. |
 | Code of Conduct | [Code of Conduct](https://github.com/ballerina-platform/ballerina-lang/blob/master/CODE_OF_CONDUCT.md) provides guidelines on participating in the Ballerina community and reporting issues. |


### PR DESCRIPTION
The link was not correct - was taking to the page that required to already have an account. Changed it to the proper landing page where you can sign up.

## Purpose
> Describe what and why this pull request. Include background information if necessary.

## Related PRs
> List any other related PRs.

## Special notes
> Any special testing needed to verify integrity.
- Any checklist items to be verified before production deployment?
- Special styling concerns? 
- Related media files? 
