### PR TITLE
Fix extra space showing between the line number and code

### DIFF
--- a/playground-widget/web/src/components/editor/CodeEditor.js
+++ b/playground-widget/web/src/components/editor/CodeEditor.js
@@ -21,7 +21,9 @@ const MONACO_OPTIONS = {
     autoClosingBrackets: true,
     matchBrackets: true,
     automaticLayout: true,
-    lineNumbersMinChars: 3,
+    lineNumbersMinChars: 2,
+    lineDecorationsWidth: 0,
+    glyphMargin: true,
     scrollBeyondLastLine: false,
     minimap: {
         enabled: false,


### PR DESCRIPTION
## Purpose
$subject

This is done by making lineDecorationsWidth 0

![image](https://user-images.githubusercontent.com/3872221/42689795-7c0d9af6-86bf-11e8-9bc2-389975599fe5.png)
