### PR TITLE
Reduce width of the line-numbers panel to the original width

### DIFF
--- a/playground-widget/web/src/components/editor/CodeEditor.css
+++ b/playground-widget/web/src/components/editor/CodeEditor.css
@@ -2,18 +2,20 @@
     height: 100%;
 }
 
-.monaco-editor .lines-content {
-    padding-left: 4px;
-}
-
 .monaco-editor .margin {
     padding-top: 4px;
+    width: 30px!important;
+}
+
+.monaco-editor .line-numbers {
+    width: 20px!important;
 }
 
 .monaco-editor .editor-scrollable {
     width: 442px!important;
     height: 277px!important;
     top: 4px!important;
+    left: 34px!important;
 }
 
 /* 

--- a/playground-widget/web/src/components/editor/CodeEditor.js
+++ b/playground-widget/web/src/components/editor/CodeEditor.js
@@ -21,9 +21,7 @@ const MONACO_OPTIONS = {
     autoClosingBrackets: true,
     matchBrackets: true,
     automaticLayout: true,
-    lineNumbersMinChars: 2,
-    lineDecorationsWidth: 0,
-    glyphMargin: true,
+    lineNumbersMinChars: 3,
     scrollBeyondLastLine: false,
     minimap: {
         enabled: false,


### PR DESCRIPTION
## Purpose
This was increased after updating monaco editor

![image](https://user-images.githubusercontent.com/3872221/42697503-eaad0dde-86d8-11e8-9ed7-36d3a3bdb56f.png)
