### PR TITLE
Fix outdated content in b7a structure doc

### DIFF
--- a/website/two-column-pages/docs/learn/how-to-structure-ballerina-code.md
+++ b/website/two-column-pages/docs/learn/how-to-structure-ballerina-code.md
@@ -187,19 +187,14 @@ The folders `.ballerina/`, `tests/`, and `resources/` are reserved folder names 
     [tests/]           # Package-specific unit and integration tests
     [resources/]       # Package-specific resources
     
-  packages.can.include.dots.in.dir.name/
+  packages.can.include.dots.inthe.dir.name/
     Package.md
     *.bal
     [tests/]         
     [resources/]     
 
-  [tests/]             # Tests executed for every package in the project
-  [resources/]         # Resources included with every package in the project
-
   target/              # Compiled binaries and other artifacts end up here
       main.balx
-      package1.balo
-      packages.can.include.dots.in.dir.name.bal
 ```
 
 Any source files located in the project root are assumed to be part of the unnamed package. They are each assumed to be entry points and compiled into `target/<file-name>.balx`. This structure is to simplify new development, but not recommended for large projects. Large projects should place the entrypoint or entry service into a named package.


### PR DESCRIPTION
## Purpose

Package structure needs the following changes to build successfully.

1) Remove empty resources and tests directories which do not need. If you have empty directories, build command will be failed.

2) Package.balo will be created with .ballerina/repo/[org-name]/[package-name]/[version]/[package-name].zip. It will not be in target/ directory.

3) When you have reserved word in package name , project build fails as well.

ex. packages.can.include.dots.in.dir.name here 'in is a reserved word hence build will be failed.

Hence rename  'packages.can.include.dots.in.dir.name' to 'packages.can.include.dots.inthe.dir.nam
 
