### PR TITLE
Remove version keyword in import declaration

### DIFF
--- a/website/two-column-pages/docs/learn/how-to-structure-ballerina-code.md
+++ b/website/two-column-pages/docs/learn/how-to-structure-ballerina-code.md
@@ -83,7 +83,7 @@ Package names can contain alphanumeric characters including dots `.`. Dots in a 
 Your Ballerina source files can import packages:
 
 ```ballerina
-import [<org-name>]/<package-name> her.package [ [version <string>] [as <identifier>] ];
+import [<org-name>]/<package-name> [as <identifier>];
 ```
 
 When importing a package, you can then use its functions, annotations and other objects in your code. You reference these objects with a qualified identifier followed by a colon `:`, such as `<identifier>:<package-object>`.


### PR DESCRIPTION
Ballerina does not support specifying the package version in the `import` package declaration. This will be added in the future. 