### PR TITLE
Use last commit id of the playground as cache Id

### DIFF
--- a/playground-widget/web/config/webpack.config.js
+++ b/playground-widget/web/config/webpack.config.js
@@ -27,10 +27,11 @@
  const HtmlWebpackPlugin = require('html-webpack-plugin');
  const CleanWebpackPlugin = require('clean-webpack-plugin');
  const MonacoWebpackPlugin = require('monaco-editor-webpack-plugin');
+ const GitRevisionPlugin = require('git-revision-webpack-plugin');
  const WebfontPlugin = require('webpack-webfont').default;
  
  const isProductionBuild = process.env.NODE_ENV === 'production';
- const hashToUse = isProductionBuild ? 'chunkhash' : 'hash';
+ const hashToUse = isProductionBuild ? 'git-revision-hash' : 'hash';
  const backendHost = 'playground.preprod.ballerina.io';
 
  const moduleRoot = path.resolve(__dirname, '../');
@@ -217,7 +218,10 @@ const codepoints = {}
         new MonacoWebpackPlugin({
             features:['bracketMatching', 'iPadShowKeyboard'],
             languages: []
-        })
+        }),
+        new GitRevisionPlugin({
+            commithashCommand: 'log -n 1 --pretty=format:%H -- .',
+        }),
      ],
      devServer: {
          port: 3000,

--- a/playground-widget/web/package-lock.json
+++ b/playground-widget/web/package-lock.json
@@ -5081,6 +5081,12 @@
         "assert-plus": "1.0.0"
       }
     },
+    "git-revision-webpack-plugin": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/git-revision-webpack-plugin/-/git-revision-webpack-plugin-2.5.1.tgz",
+      "integrity": "sha1-P7Q5jzds8nZ41t6WuiZptRhkXng=",
+      "dev": true
+    },
     "glob": {
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",

--- a/playground-widget/web/package.json
+++ b/playground-widget/web/package.json
@@ -68,6 +68,7 @@
     "clean-webpack-plugin": "^0.1.19",
     "cross-env": "^5.1.3",
     "eslint-config-airbnb": "^16.1.0",
+    "git-revision-webpack-plugin": "^2.5.1",
     "node-sass": "^4.7.2",
     "progress-bar-webpack-plugin": "^1.11.0",
     "raw-loader": "^0.5.1",


### PR DESCRIPTION
With this, cache of playground assets will only
be cleared when there are actual changes to it.
Otherwise each build will cause its cache to be
invalidated. We also need to improve this logic
to keep vendor bundle hash intact unless package
json is changed.
