### PR TITLE
Fix broken link for IDE integrations in Quick Tour

### DIFF
--- a/website/two-column-pages/docs/learn/quick-tour.md
+++ b/website/two-column-pages/docs/learn/quick-tour.md
@@ -103,7 +103,7 @@ service hello on new http:Listener(9090) {
 
 You can find a plugin for Ballerina in the VS Code marketplace. This helps read the `.bal` file using an ideal theme. 
 
-> **Tip:** You can use your [favourite editor to work on Ballerina code](https://github.com/ballerina-platform/ballerina-lang/blob/master/docs/tools-ides.md).
+> **Tip:** You can use your [favourite editor to work on Ballerina code](https://github.com/ballerina-platform/ballerina-lang/blob/master/docs/tools-ides-ballerina-composer.md).
 
 ### Annotations
 


### PR DESCRIPTION
## Purpose
The link that informs users they can use their favorite IDE was broken. This commit fixes that by pointing that link to the right location.

## Related PRs
N/A

## Special notes
N/A