### PR TITLE
Fix OpenAPI code generator title and links

### DIFF
--- a/website/two-column-pages/docs/learn/tools-ides.md
+++ b/website/two-column-pages/docs/learn/tools-ides.md
@@ -18,7 +18,7 @@ The graphical visualization tool is embedded in the Visual Studio Code plug-in.
 
 ## OpenAPI to Ballerina code generator
 
-You can use existing OpenAPI/Swagger files to generate connectors and services in Ballerina code. For details, see the [OpenAPI to Ballerina Code Generator](https://ballerina.io/learn/by-guide/open-api-based-service/).
+You can use the existing OpenAPI/Swagger files to generate connectors and services using Ballerina code. For details, see the [OpenAPI to Ballerina Code Generator](https://ballerina.io/learn/by-guide/open-api-based-service/).
 
 ## API documentation generator
 

--- a/website/two-column-pages/docs/learn/tools-ides.md
+++ b/website/two-column-pages/docs/learn/tools-ides.md
@@ -3,7 +3,7 @@
 Ballerina provides language servers, editors, IDEs, and graphical visualization tools to help you write, document, and test your code. The sections below introduce you to them. 
 
 - [Editor and IDE support](#editor-and-ide-support)
-- [Swagger to Ballerina code generator](#swagger-to-ballerina-code-generator)
+- [OpenAPI to Ballerina code generator](#openapi-to-ballerina-code-generator)
 - [API documentation generator](#api-documentation-generator)
 - [Test framework](#test-framework)
 
@@ -16,9 +16,9 @@ You can use plugins to write Ballerina code in your favorite editor or IDE. Clic
 
 The graphical visualization tool is embedded in the Visual Studio Code plug-in.
 
-## OpenAPI/Swagger to Ballerina code generator
+## OpenAPI to Ballerina code generator
 
-You can use existing OpenAPI/Swagger files to generate connectors and services in Ballerina code. For details, see the [OpenAPI/Swagger to Ballerina Code Generator](https://ballerina.io/learn/by-guide/open-api-based-service/).
+You can use existing OpenAPI/Swagger files to generate connectors and services in Ballerina code. For details, see the [OpenAPI to Ballerina Code Generator](https://ballerina.io/learn/by-guide/open-api-based-service/).
 
 ## API documentation generator
 

--- a/website/two-column-pages/docs/learn/tools-ides.md
+++ b/website/two-column-pages/docs/learn/tools-ides.md
@@ -18,7 +18,7 @@ The graphical visualization tool is embedded in the Visual Studio Code plug-in.
 
 ## OpenAPI to Ballerina code generator
 
-You can use the existing OpenAPI/Swagger files to generate connectors and services using Ballerina code. For details, see the [OpenAPI to Ballerina Code Generator](https://ballerina.io/learn/by-guide/open-api-based-service/).
+You can use the existing OpenAPI/Swagger files to generate connectors and services in Ballerina code. For details, see the [OpenAPI to Ballerina Code Generator](https://ballerina.io/learn/by-guide/open-api-based-service/).
 
 ## API documentation generator
 


### PR DESCRIPTION
## Purpose
This will replace "Swagger" with "OpenAPI" and fix any broken navigation for the titles.

## Related PRs
* https://github.com/ballerina-platform/ballerina-www/pull/1413
* https://github.com/ballerina-platform/ballerina-www/pull/1411
