### PR TITLE
Change all security@wso2.com occurrences

### DIFF
--- a/website/two-column-pages/docs/security.md
+++ b/website/two-column-pages/docs/security.md
@@ -8,7 +8,7 @@ This is a private mailing list where only members of the WSO2 internal security 
 
 If you wish to send secure messages to [security@ballerina.io](mailto:security@ballerina.io), you may use the following key:
 
-security@wso2.com: 0168 DA26 2989 0DB9 4ACD  8367 E683 061E 2F85 C381 [pgp.mit.edu](https://pgp.surfnet.nl/pks/lookup?op=vindex&fingerprint=on&search=0xE683061E2F85C381)
+security@ballerina.io: 0168 DA26 2989 0DB9 4ACD  8367 E683 061E 2F85 C381 [pgp.mit.edu](https://pgp.surfnet.nl/pks/lookup?op=vindex&fingerprint=on&search=0xE683061E2F85C381)
 
 ## Vulnerability Information
 


### PR DESCRIPTION
## Purpose
This is to replace all occurrences of the usage of security@wso2.com email address in the Ballerina website to security@ballerina.io.

## Related PRs
https://github.com/ballerina-platform/ballerina-www/pull/1436/files

## Special notes
> Any special testing needed to verify integrity.
- Any checklist items to be verified before production deployment?
- Special styling concerns? 
- Related media files? 
