### PR TITLE
Add buttons of the IDE logos

### DIFF
--- a/website/two-column-pages/docs/learn/tools-ides.md
+++ b/website/two-column-pages/docs/learn/tools-ides.md
@@ -11,8 +11,8 @@ Ballerina provides language servers, editors, IDEs, and graphical visualization 
 
 You can use plugins to write Ballerina code in your favorite editor or IDE. Click on the below icons to learn about the plugins that are currently available. 
 
-[![VS Code](images/vscode-logo.png)](tools-ides/vscode-plugin) 
-[![IntelliJ](images/intellij-logo.png)](tools-ides/intellij-plugin)
+![VS Code](images/vscode-logo.jpg)&nbsp;&nbsp;[Visual Studio Code](tools-ides/vscode-plugin) &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+![IntelliJ](images/idea-logo.jpg)&nbsp;&nbsp;[IntelliJ IDEA](tools-ides/intellij-plugin)
 
 The graphical visualization tool is embedded in the Visual Studio Code plug-in.
 


### PR DESCRIPTION
## Purpose
This is to add 2 buttons in [1] to direct users to the IDEA and VSCode pages.

[1] https://ballerina.io/learn/tools-ides/

## Related PRs
> List any other related PRs.

## Special notes
> Any special testing needed to verify integrity.
- Any checklist items to be verified before production deployment?
- Special styling concerns? 
- Related media files? 
