### PR TITLE
Replace the `ballerina create` command with `ballerina add`

### DIFF
--- a/website/two-column-pages/docs/learn/how-to-document-ballerina-code.md
+++ b/website/two-column-pages/docs/learn/how-to-document-ballerina-code.md
@@ -127,11 +127,11 @@ $ ballerina init
 Ballerina project initialised
 
 Next:
-    Use `ballerina create` to create a ballerina module.
-$ ballerina create math -t service
-Created new ballerina module at 'src/math'
-$ ballerina create time -t service
-Created new ballerina module at 'src/time'
+    Use `ballerina add` to add a Ballerina module.
+$ ballerina add math -t service
+Added new ballerina module at 'src/math'
+$ ballerina add time -t service
+Added new ballerina module at 'src/time'
 
 ```
 Now, let's generate documentation of the project:

--- a/website/two-column-pages/docs/learn/how-to-structure-ballerina-code.md
+++ b/website/two-column-pages/docs/learn/how-to-structure-ballerina-code.md
@@ -189,13 +189,13 @@ it will give an error.
 
 It will create the `Ballerina.toml` file, `src` folder, and a `tests` folder.
 
-### Create a Module
-Once the project is initialized, a module can be created inside the project using the `ballerina create` command. 
+### Add a Module
+Once the project is initialized, a module can be created inside the project using the `ballerina add` command. 
 Each subdirectory of the project `src` folder defines a single module. The subdirectory's name will be used to name the 
 module. 
 
 ```bash
-ballerina create <module-name>
+ballerina add <module-name>
 ```
 
 The folders `tests/` and `resources/` are reserved folder names within the module. The `tests/` folder contains 

--- a/website/two-column-pages/docs/learn/quick-tour.md
+++ b/website/two-column-pages/docs/learn/quick-tour.md
@@ -21,7 +21,7 @@ $ ballerina new quick-tour
 You see a response confirming that your project is created and directing you to create a new module within the project. In order to create the new module, change the working directory to the newly created project folder. Afterwards, run the following command with the module name `sample_service` and the template name `service`
 
 ```bash
-$ ballerina create sample_service -t service
+$ ballerina add sample_service -t service
 ```
 
 This automatically creates a typical Hello World service for you in your directory. A Ballerina service represents a collection of network accessible entry points in Ballerina. A resource within a service represents one such entry point. The generated sample service exposes a network entry point on port 9090.


### PR DESCRIPTION
## Purpose
This is to replace the `ballerina create` command with `ballerina add` in the content of the Ballerina website.

Fixes https://github.com/ballerina-platform/ballerina-lang/issues/17897.

## Related PRs
> List any other related PRs.

## Special notes
> Any special testing needed to verify integrity.
- Any checklist items to be verified before production deployment?
- Special styling concerns? 
- Related media files? 
