### PR TITLE
Use ballerina module run command

### DIFF
--- a/website/two-column-pages/docs/learn/quick-tour.md
+++ b/website/two-column-pages/docs/learn/quick-tour.md
@@ -26,16 +26,10 @@ $ ballerina add sample_service -t service
 
 This automatically creates a typical Hello World service for you in your directory. A Ballerina service represents a collection of network accessible entry points in Ballerina. A resource within a service represents one such entry point. The generated sample service exposes a network entry point on port 9090.
 
-In order to run the service, you need to build the project using the following command.
-
-```bash
-$ ballerina build
-```
-
 Now, you can run the service by running the following command. 
 
 ```bash
-$ ballerina run /<folder_path>/sample_service-executable.jar
+$ ballerina run sample_service
 ```
 
 You get the following output.
@@ -214,16 +208,10 @@ service sunriseSunset on new http:Listener(9090) {
 
 Now, before we build the module, let's change the `sample_service.bal` to `sunrise_sunset_service.bal`.
 
-All set. Once again, let's build the module by running the below command.
-
-```bash
-$ ballerina build
-```
-
 Now, you can run the service by running the following command. 
 
 ```bash
-$ ballerina run /<folder_path>/sample_service-executable.jar
+$ ballerina run sample_service
 ```
 
 As before, you should get the following output.


### PR DESCRIPTION
## Purpose
Replace separate build and run commands with single module run step.

1. We no longer generate .jar's in the module directory (now it's all in project's target/bin)
2. I think it's better to use simpler step in `quick-tour`

## Related PRs
> List any other related PRs.

## Special notes
> Any special testing needed to verify integrity.
- Any checklist items to be verified before production deployment?
- Special styling concerns? 
- Related media files? 
